### PR TITLE
その他のユーザー情報フォームを追加

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,7 +20,10 @@
 
   <div class="field">
     <%= f.label :gender %><br />
-    <%= f.text_field :gender %>
+    <label><%= f.radio_button :gender, "0" %> 男性 </label>
+    <label><%= f.radio_button :gender, "1" %> 女性 </label>
+    <label><%= f.radio_button :gender, "2" %> その他 </label>
+    <label><%= f.radio_button :gender, "9" %> 答えたくない </label>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -31,14 +34,18 @@
     <%= f.label :password %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %>文字以上</em>
+      <em>＊<%= @minimum_password_length %>文字以上</em>
     <% end %>
   </div>
 
   <div class="field">
     <%= f.label :bike_type %><br />
-    <%= f.text_field :bike_type %>
+    <label><%= f.radio_button :bike_type, "ネイキッド" %> ネイキッド </label>
+    <label><%= f.radio_button :bike_type, "SS" %> SS </label>
+    <label><%= f.radio_button :bike_type, "クルーザー" %> クルーザー </label>
+    <label><%= f.radio_button :bike_type, "オフロード" %> オフロード </label>
+    <label><%= f.radio_button :bike_type, "原付" %> 原付 </label>
+    <label><%= f.radio_button :bike_type, "スクーター" %> スクーター </label>
   </div>
 
   <div class="field">
@@ -58,7 +65,8 @@
 
   <div class="field">
     <%= f.label :through %><br />
-    <%= f.text_field :through %>
+    <label><%= f.radio_button :through, "false" %> 不可 </label>
+    <label><%= f.radio_button :through, "true" %> 可 </label>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2>アカウント編集</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -13,26 +13,56 @@
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
+  <div class="field">
+    <%= f.label :age %><br />
+    <%= f.text_field :age %>
+  </div>
+
+  <div class="field">
+    <%= f.label :gender %><br />
+    <%= f.text_field :gender %>
+  </div>
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= @minimum_password_length %>文字以上</em>
     <% end %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.label :bike_type %><br />
+    <%= f.text_field :bike_type %>
+  </div>
+
+  <div class="field">
+    <%= f.label :bike_name %><br />
+    <%= f.text_field :bike_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :engine_size %><br />
+    <%= f.text_field :engine_size %>
+  </div>
+
+  <div class="field">
+    <%= f.label :experience_years %><br />
+    <%= f.text_field :experience_years %>
+  </div>
+
+  <div class="field">
+    <%= f.label :through %><br />
+    <%= f.text_field :through %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "更新" %>
   </div>
 <% end %>
 
@@ -40,4 +70,4 @@
 
 <p><%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
-<%= link_to "Back", :back %>
+<%= link_to "戻る", :back %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -22,9 +22,14 @@ ja:
         current_password: "現在のパスワード"
         name: 名前
         email: "メールアドレス"
+        age: "年齢"
+        gender: "性別"
         password: "パスワード"
-        password_confirmation: "確認用パスワード"
-        remember_me: "次回から自動的にログイン"
+        bike_type: "車種"
+        bike_name: "愛車名"
+        engine_size: "排気量"
+        experience_years: "バイク歴"
+        through: "すり抜け可否"
     models:
       user: "ユーザ"
   devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
+  get 'users/edit_bike' => ''
   get 'users/show' => 'users#show'
   root :to => 'home#index'
 


### PR DESCRIPTION
## 実装内容

- ユーザー情報更新ページを編集
    - ユーザー関連(年齢、性別)
    - バイク関連(車種、車名、排気量)
    - バイク経験関連(経験年数、すり抜け可否)

- 各種日本語化
- 一部ラジオボタン