### PR TITLE
ロゴの遷移先を一覧ページへ修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-md navbar-light navbar-style pr-5">
-  <%= link_to image_tag("logo-icon.png"), "/", class: "navbar-brand logo-image" %>
+  <%= link_to image_tag("logo-icon.png"), roads_path, class: "navbar-brand logo-image" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#responsiveMenu" aria-controls="responsiveMenu" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>


### PR DESCRIPTION
## 修正内容

ロゴをクリックしたときの遷移先を投稿一覧ページに修正